### PR TITLE
Feature/nlp normaliser functions

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,5 +1,5 @@
 ;;; Directory Local Variables
 ;;; For more information see (info "(emacs) Directory Variables")
 
-((nil . ((compile-command . "cd $(git rev-parse --show-toplevel) && poetry run black .;poetry run pycodestyle .;poetry run flake8 .;poetry run mypy .;poetry run pytest -v")))
- (python-mode . ((compile-command . "cd $(git rev-parse --show-toplevel) && poetry run black .;poetry run pycodestyle .;poetry run flake8 .;poetry run mypy .;poetry run pytest -v"))))
+((nil . ((compile-command . "cd $(git rev-parse --show-toplevel) && poetry run black .;poetry run pycodestyle .;poetry run flake8 .;poetry run mypy .;poetry run pytest -vv")))
+ (python-mode . ((compile-command . "cd $(git rev-parse --show-toplevel) && poetry run black .;poetry run pycodestyle .;poetry run flake8 .;poetry run mypy .;poetry run pytest -vv"))))

--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,5 +1,5 @@
 ;;; Directory Local Variables
 ;;; For more information see (info "(emacs) Directory Variables")
 
-((nil . ((compile-command . "cd $(git rev-parse --show-toplevel) && poetry run black .;pycodestyle .;flake8 .;mypy .;pytest")))
- (python-mode . ((compile-command . "cd $(git rev-parse --show-toplevel) && poetry run black .;pycodestyle .;flake8 .;mypy .;pytest"))))
+((nil . ((compile-command . "cd $(git rev-parse --show-toplevel) && poetry run black .;poetry run pycodestyle .;poetry run flake8 .;poetry run mypy .;poetry run pytest -v")))
+ (python-mode . ((compile-command . "cd $(git rev-parse --show-toplevel) && poetry run black .;poetry run pycodestyle .;poetry run flake8 .;poetry run mypy .;poetry run pytest -v"))))

--- a/poetry.lock
+++ b/poetry.lock
@@ -50,7 +50,7 @@ uvloop = ["uvloop (>=0.15.2)"]
 name = "click"
 version = "8.0.3"
 description = "Composable command line interface toolkit"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -61,7 +61,7 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 name = "colorama"
 version = "0.4.4"
 description = "Cross-platform colored terminal text."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
@@ -138,6 +138,14 @@ pydantic = ">=1.7,<2.0"
 pygls = ">=0.11.1,<0.12.0"
 
 [[package]]
+name = "joblib"
+version = "1.1.0"
+description = "Lightweight pipelining with Python functions"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "mccabe"
 version = "0.6.1"
 description = "McCabe checker, plugin for flake8"
@@ -169,6 +177,28 @@ description = "Experimental type system extensions for programs checked with the
 category = "dev"
 optional = false
 python-versions = "*"
+
+[[package]]
+name = "nltk"
+version = "3.6.6"
+description = "Natural Language Toolkit"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+click = "*"
+joblib = "*"
+regex = ">=2021.8.3"
+tqdm = "*"
+
+[package.extras]
+all = ["scikit-learn", "twython", "python-crfsuite", "numpy", "requests", "scipy", "matplotlib", "pyparsing"]
+corenlp = ["requests"]
+machine_learning = ["numpy", "python-crfsuite", "scikit-learn", "scipy"]
+plot = ["matplotlib"]
+tgrep = ["pyparsing"]
+twitter = ["twython"]
 
 [[package]]
 name = "packaging"
@@ -353,6 +383,14 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 pytest = ">=2.9.0"
 
 [[package]]
+name = "regex"
+version = "2021.11.10"
+description = "Alternative regular expression module, to replace re."
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "toml"
 version = "0.10.2"
 description = "Python Library for Tom's Obvious, Minimal Language"
@@ -367,6 +405,22 @@ description = "A lil' TOML parser"
 category = "dev"
 optional = false
 python-versions = ">=3.6"
+
+[[package]]
+name = "tqdm"
+version = "4.62.3"
+description = "Fast, Extensible Progress Meter"
+category = "main"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[package.extras]
+dev = ["py-make (>=0.1.0)", "twine", "wheel"]
+notebook = ["ipywidgets (>=6)"]
+telegram = ["requests"]
 
 [[package]]
 name = "typeguard"
@@ -391,7 +445,7 @@ python-versions = ">=3.6"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "78203e6849b77c5184582db6bf3331367e8568399da4481b7ec3652fcc1db968"
+content-hash = "56b94ae74b41f43ce2b49939e04a96bb2dc148dafe15dd9247e785ece74d2d89"
 
 [metadata.files]
 atomicwrites = [
@@ -483,6 +537,10 @@ jedi-language-server = [
     {file = "jedi-language-server-0.35.0.tar.gz", hash = "sha256:d11d63741c4fc9052444e407ae77785a00dcb2bcdea71b29a2e17b03abaacc49"},
     {file = "jedi_language_server-0.35.0-py3-none-any.whl", hash = "sha256:4bda79a4ab3d2e6522ee78bc561de980f954757f9c84b8cd650a6645b6d30fd9"},
 ]
+joblib = [
+    {file = "joblib-1.1.0-py2.py3-none-any.whl", hash = "sha256:f21f109b3c7ff9d95f8387f752d0d9c34a02aa2f7060c2135f465da0e5160ff6"},
+    {file = "joblib-1.1.0.tar.gz", hash = "sha256:4158fcecd13733f8be669be0683b96ebdbbd38d23559f54dca7205aea1bf1e35"},
+]
 mccabe = [
     {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
     {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
@@ -512,6 +570,10 @@ mypy = [
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
+]
+nltk = [
+    {file = "nltk-3.6.6-py3-none-any.whl", hash = "sha256:69470ba480ff4408e8ea82c530c8dc9571bab899f49d4571e8c8833e0916abd0"},
+    {file = "nltk-3.6.6.zip", hash = "sha256:0f8ff4e261c78605bca284e8d2025e562304766156af32a1731f56b396ee364b"},
 ]
 packaging = [
     {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
@@ -593,6 +655,82 @@ pytest-metadata = [
     {file = "pytest-metadata-1.11.0.tar.gz", hash = "sha256:71b506d49d34e539cc3cfdb7ce2c5f072bea5c953320002c95968e0238f8ecf1"},
     {file = "pytest_metadata-1.11.0-py2.py3-none-any.whl", hash = "sha256:576055b8336dd4a9006dd2a47615f76f2f8c30ab12b1b1c039d99e834583523f"},
 ]
+regex = [
+    {file = "regex-2021.11.10-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9345b6f7ee578bad8e475129ed40123d265464c4cfead6c261fd60fc9de00bcf"},
+    {file = "regex-2021.11.10-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:416c5f1a188c91e3eb41e9c8787288e707f7d2ebe66e0a6563af280d9b68478f"},
+    {file = "regex-2021.11.10-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e0538c43565ee6e703d3a7c3bdfe4037a5209250e8502c98f20fea6f5fdf2965"},
+    {file = "regex-2021.11.10-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7ee1227cf08b6716c85504aebc49ac827eb88fcc6e51564f010f11a406c0a667"},
+    {file = "regex-2021.11.10-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6650f16365f1924d6014d2ea770bde8555b4a39dc9576abb95e3cd1ff0263b36"},
+    {file = "regex-2021.11.10-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:30ab804ea73972049b7a2a5c62d97687d69b5a60a67adca07eb73a0ddbc9e29f"},
+    {file = "regex-2021.11.10-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:68a067c11463de2a37157930d8b153005085e42bcb7ad9ca562d77ba7d1404e0"},
+    {file = "regex-2021.11.10-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:162abfd74e88001d20cb73ceaffbfe601469923e875caf9118333b1a4aaafdc4"},
+    {file = "regex-2021.11.10-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:b9ed0b1e5e0759d6b7f8e2f143894b2a7f3edd313f38cf44e1e15d360e11749b"},
+    {file = "regex-2021.11.10-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:473e67837f786404570eae33c3b64a4b9635ae9f00145250851a1292f484c063"},
+    {file = "regex-2021.11.10-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:2fee3ed82a011184807d2127f1733b4f6b2ff6ec7151d83ef3477f3b96a13d03"},
+    {file = "regex-2021.11.10-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:d5fd67df77bab0d3f4ea1d7afca9ef15c2ee35dfb348c7b57ffb9782a6e4db6e"},
+    {file = "regex-2021.11.10-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:5d408a642a5484b9b4d11dea15a489ea0928c7e410c7525cd892f4d04f2f617b"},
+    {file = "regex-2021.11.10-cp310-cp310-win32.whl", hash = "sha256:98ba568e8ae26beb726aeea2273053c717641933836568c2a0278a84987b2a1a"},
+    {file = "regex-2021.11.10-cp310-cp310-win_amd64.whl", hash = "sha256:780b48456a0f0ba4d390e8b5f7c661fdd218934388cde1a974010a965e200e12"},
+    {file = "regex-2021.11.10-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:dba70f30fd81f8ce6d32ddeef37d91c8948e5d5a4c63242d16a2b2df8143aafc"},
+    {file = "regex-2021.11.10-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e1f54b9b4b6c53369f40028d2dd07a8c374583417ee6ec0ea304e710a20f80a0"},
+    {file = "regex-2021.11.10-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fbb9dc00e39f3e6c0ef48edee202f9520dafb233e8b51b06b8428cfcb92abd30"},
+    {file = "regex-2021.11.10-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:666abff54e474d28ff42756d94544cdfd42e2ee97065857413b72e8a2d6a6345"},
+    {file = "regex-2021.11.10-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5537f71b6d646f7f5f340562ec4c77b6e1c915f8baae822ea0b7e46c1f09b733"},
+    {file = "regex-2021.11.10-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ed2e07c6a26ed4bea91b897ee2b0835c21716d9a469a96c3e878dc5f8c55bb23"},
+    {file = "regex-2021.11.10-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:ca5f18a75e1256ce07494e245cdb146f5a9267d3c702ebf9b65c7f8bd843431e"},
+    {file = "regex-2021.11.10-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:74cbeac0451f27d4f50e6e8a8f3a52ca074b5e2da9f7b505c4201a57a8ed6286"},
+    {file = "regex-2021.11.10-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:3598893bde43091ee5ca0a6ad20f08a0435e93a69255eeb5f81b85e81e329264"},
+    {file = "regex-2021.11.10-cp36-cp36m-musllinux_1_1_ppc64le.whl", hash = "sha256:50a7ddf3d131dc5633dccdb51417e2d1910d25cbcf842115a3a5893509140a3a"},
+    {file = "regex-2021.11.10-cp36-cp36m-musllinux_1_1_s390x.whl", hash = "sha256:61600a7ca4bcf78a96a68a27c2ae9389763b5b94b63943d5158f2a377e09d29a"},
+    {file = "regex-2021.11.10-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:563d5f9354e15e048465061509403f68424fef37d5add3064038c2511c8f5e00"},
+    {file = "regex-2021.11.10-cp36-cp36m-win32.whl", hash = "sha256:93a5051fcf5fad72de73b96f07d30bc29665697fb8ecdfbc474f3452c78adcf4"},
+    {file = "regex-2021.11.10-cp36-cp36m-win_amd64.whl", hash = "sha256:b483c9d00a565633c87abd0aaf27eb5016de23fed952e054ecc19ce32f6a9e7e"},
+    {file = "regex-2021.11.10-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:fff55f3ce50a3ff63ec8e2a8d3dd924f1941b250b0aac3d3d42b687eeff07a8e"},
+    {file = "regex-2021.11.10-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e32d2a2b02ccbef10145df9135751abea1f9f076e67a4e261b05f24b94219e36"},
+    {file = "regex-2021.11.10-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:53db2c6be8a2710b359bfd3d3aa17ba38f8aa72a82309a12ae99d3c0c3dcd74d"},
+    {file = "regex-2021.11.10-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2207ae4f64ad3af399e2d30dde66f0b36ae5c3129b52885f1bffc2f05ec505c8"},
+    {file = "regex-2021.11.10-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d5ca078bb666c4a9d1287a379fe617a6dccd18c3e8a7e6c7e1eb8974330c626a"},
+    {file = "regex-2021.11.10-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dd33eb9bdcfbabab3459c9ee651d94c842bc8a05fabc95edf4ee0c15a072495e"},
+    {file = "regex-2021.11.10-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:05b7d6d7e64efe309972adab77fc2af8907bb93217ec60aa9fe12a0dad35874f"},
+    {file = "regex-2021.11.10-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:42b50fa6666b0d50c30a990527127334d6b96dd969011e843e726a64011485da"},
+    {file = "regex-2021.11.10-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:6e1d2cc79e8dae442b3fa4a26c5794428b98f81389af90623ffcc650ce9f6732"},
+    {file = "regex-2021.11.10-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:0416f7399e918c4b0e074a0f66e5191077ee2ca32a0f99d4c187a62beb47aa05"},
+    {file = "regex-2021.11.10-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:ce298e3d0c65bd03fa65ffcc6db0e2b578e8f626d468db64fdf8457731052942"},
+    {file = "regex-2021.11.10-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:dc07f021ee80510f3cd3af2cad5b6a3b3a10b057521d9e6aaeb621730d320c5a"},
+    {file = "regex-2021.11.10-cp37-cp37m-win32.whl", hash = "sha256:e71255ba42567d34a13c03968736c5d39bb4a97ce98188fafb27ce981115beec"},
+    {file = "regex-2021.11.10-cp37-cp37m-win_amd64.whl", hash = "sha256:07856afef5ffcc052e7eccf3213317fbb94e4a5cd8177a2caa69c980657b3cb4"},
+    {file = "regex-2021.11.10-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ba05430e819e58544e840a68b03b28b6d328aff2e41579037e8bab7653b37d83"},
+    {file = "regex-2021.11.10-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:7f301b11b9d214f83ddaf689181051e7f48905568b0c7017c04c06dfd065e244"},
+    {file = "regex-2021.11.10-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4aaa4e0705ef2b73dd8e36eeb4c868f80f8393f5f4d855e94025ce7ad8525f50"},
+    {file = "regex-2021.11.10-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:788aef3549f1924d5c38263104dae7395bf020a42776d5ec5ea2b0d3d85d6646"},
+    {file = "regex-2021.11.10-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f8af619e3be812a2059b212064ea7a640aff0568d972cd1b9e920837469eb3cb"},
+    {file = "regex-2021.11.10-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:85bfa6a5413be0ee6c5c4a663668a2cad2cbecdee367630d097d7823041bdeec"},
+    {file = "regex-2021.11.10-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f23222527b307970e383433daec128d769ff778d9b29343fb3496472dc20dabe"},
+    {file = "regex-2021.11.10-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:da1a90c1ddb7531b1d5ff1e171b4ee61f6345119be7351104b67ff413843fe94"},
+    {file = "regex-2021.11.10-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:f5be7805e53dafe94d295399cfbe5227f39995a997f4fd8539bf3cbdc8f47ca8"},
+    {file = "regex-2021.11.10-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:a955b747d620a50408b7fdf948e04359d6e762ff8a85f5775d907ceced715129"},
+    {file = "regex-2021.11.10-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:139a23d1f5d30db2cc6c7fd9c6d6497872a672db22c4ae1910be22d4f4b2068a"},
+    {file = "regex-2021.11.10-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:ca49e1ab99593438b204e00f3970e7a5f70d045267051dfa6b5f4304fcfa1dbf"},
+    {file = "regex-2021.11.10-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:96fc32c16ea6d60d3ca7f63397bff5c75c5a562f7db6dec7d412f7c4d2e78ec0"},
+    {file = "regex-2021.11.10-cp38-cp38-win32.whl", hash = "sha256:0617383e2fe465732af4509e61648b77cbe3aee68b6ac8c0b6fe934db90be5cc"},
+    {file = "regex-2021.11.10-cp38-cp38-win_amd64.whl", hash = "sha256:a3feefd5e95871872673b08636f96b61ebef62971eab044f5124fb4dea39919d"},
+    {file = "regex-2021.11.10-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f7f325be2804246a75a4f45c72d4ce80d2443ab815063cdf70ee8fb2ca59ee1b"},
+    {file = "regex-2021.11.10-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:537ca6a3586931b16a85ac38c08cc48f10fc870a5b25e51794c74df843e9966d"},
+    {file = "regex-2021.11.10-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eef2afb0fd1747f33f1ee3e209bce1ed582d1896b240ccc5e2697e3275f037c7"},
+    {file = "regex-2021.11.10-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:432bd15d40ed835a51617521d60d0125867f7b88acf653e4ed994a1f8e4995dc"},
+    {file = "regex-2021.11.10-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b43c2b8a330a490daaef5a47ab114935002b13b3f9dc5da56d5322ff218eeadb"},
+    {file = "regex-2021.11.10-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:962b9a917dd7ceacbe5cd424556914cb0d636001e393b43dc886ba31d2a1e449"},
+    {file = "regex-2021.11.10-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fa8c626d6441e2d04b6ee703ef2d1e17608ad44c7cb75258c09dd42bacdfc64b"},
+    {file = "regex-2021.11.10-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3c5fb32cc6077abad3bbf0323067636d93307c9fa93e072771cf9a64d1c0f3ef"},
+    {file = "regex-2021.11.10-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:cd410a1cbb2d297c67d8521759ab2ee3f1d66206d2e4328502a487589a2cb21b"},
+    {file = "regex-2021.11.10-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:e6096b0688e6e14af6a1b10eaad86b4ff17935c49aa774eac7c95a57a4e8c296"},
+    {file = "regex-2021.11.10-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:529801a0d58809b60b3531ee804d3e3be4b412c94b5d267daa3de7fadef00f49"},
+    {file = "regex-2021.11.10-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:0f594b96fe2e0821d026365f72ac7b4f0b487487fb3d4aaf10dd9d97d88a9737"},
+    {file = "regex-2021.11.10-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:2409b5c9cef7054dde93a9803156b411b677affc84fca69e908b1cb2c540025d"},
+    {file = "regex-2021.11.10-cp39-cp39-win32.whl", hash = "sha256:3b5df18db1fccd66de15aa59c41e4f853b5df7550723d26aa6cb7f40e5d9da5a"},
+    {file = "regex-2021.11.10-cp39-cp39-win_amd64.whl", hash = "sha256:83ee89483672b11f8952b158640d0c0ff02dc43d9cb1b70c1564b49abe92ce29"},
+    {file = "regex-2021.11.10.tar.gz", hash = "sha256:f341ee2df0999bfdf7a95e448075effe0db212a59387de1a70690e4acb03d4c6"},
+]
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
@@ -600,6 +738,10 @@ toml = [
 tomli = [
     {file = "tomli-1.2.3-py3-none-any.whl", hash = "sha256:e3069e4be3ead9668e21cb9b074cd948f7b3113fd9c8bba083f48247aab8b11c"},
     {file = "tomli-1.2.3.tar.gz", hash = "sha256:05b6166bff487dc068d322585c7ea4ef78deed501cc124060e0f238e89a9231f"},
+]
+tqdm = [
+    {file = "tqdm-4.62.3-py2.py3-none-any.whl", hash = "sha256:8dd278a422499cd6b727e6ae4061c40b48fce8b76d1ccbf5d34fca9b7f925b0c"},
+    {file = "tqdm-4.62.3.tar.gz", hash = "sha256:d359de7217506c9851b7869f3708d8ee53ed70a1b8edbba4dbcb47442592920d"},
 ]
 typeguard = [
     {file = "typeguard-2.13.3-py3-none-any.whl", hash = "sha256:5e3e3be01e887e7eafae5af63d1f36c849aaa94e3a0112097312aabfa16284f1"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,12 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.9"
+nltk = "^3.6.6"
+# TODO: additional dependencies trying out: https://www.nltk.org/index.html
+# nltk.download('punkt')
+# nltk.download('averaged_perceptron_tagger')
+# nltk.download('stopwords')
+# 
 
 [tool.poetry.dev-dependencies]
 black = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,16 @@ exclude = '''
 '''
 
 
+[[tool.mypy.overrides]]
+# NOTE: The `nltk` module doesn't appear to maintain an internal or separate
+# PEP-561 type file. See:
+#
+# https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-library-stubs-or-py-typed-marker
+# https://mypy.readthedocs.io/en/stable/config_file.html?highlight=pyproject.toml#using-a-pyproject-toml-file
+module = "nltk.*"
+ignore_missing_imports = true
+
+
 [tool.pytest.ini_options]
 # Directories that are not visited by pytest collector:
 norecursedirs = [

--- a/python_homework_nlp/common.py
+++ b/python_homework_nlp/common.py
@@ -1,0 +1,15 @@
+import logging
+from nltk import download
+
+log = logging.getLogger(__name__)
+REQ_NLTK_DATA = (
+    "punkt",
+    "stopwords",
+)
+
+
+def download_nltk_data() -> None:
+    """Downloads all required NLTK data."""
+    for x in REQ_NLTK_DATA:
+        logging.debug("Downloading required NLTK data: %r", x)
+        download(x)

--- a/python_homework_nlp/counter.py
+++ b/python_homework_nlp/counter.py
@@ -1,0 +1,74 @@
+from collections import Counter
+
+
+def _get_word_counts(tokens: list) -> Counter:
+    return Counter(tokens)
+
+
+def _sum_collection_counters(counters: list) -> Counter:
+    total_counter: Counter = Counter()
+    for x in counters:
+        total_counter += x
+    return total_counter
+
+
+def _get_matches(word: str, orig: dict) -> dict:
+    """Returns all files + sentences that match a given word.
+
+    :param str word: word to find matches for.
+    :param dict orig: Original nested dictionary of files and original sentences
+    + filtered tokens.
+    {<filename>: {"original_sentences": [<str>,], "filtered_tokens": [[<str>,],]}}
+    :returns: dict of: {"matches": <list>, "files": <list>}
+    """
+    # TOOD: test
+    _matched_files = []
+    _matched_sentences = []
+    for _file in orig:
+        _matches = _get_matches_by_word(word, orig[_file]["original_sentences"])
+        if _matches:
+            _matched_files.append(_file)
+            _matched_sentences.extend(_matches)
+
+    return {"matches": _matched_sentences, "files": _matched_files}
+
+
+def _get_matches_by_word(word: str, original_sentences: list) -> list:
+    """Returns all sentences that match a given word.
+
+    :param str word: word to find matches for.
+    :param list orig_sentences: List of sentences to find matches in.
+    :returns: list of matched sentences.
+    """
+    # TOOD: test
+    return [x for x in original_sentences if word in x.lower()]
+
+
+def counter(orig: dict, most_common: int = None) -> dict:
+    """Counts number of words duplicate words in a filtered tokens list +
+    generates the return structure.
+
+    :param dict orig: Original nested dictionary of files and original sentences
+    + filtered tokens.
+    {<filename>: {"original_sentences": [<str>,], "filtered_tokens": [[<str>,],]}}
+    :param int most_common: Returns X most common words. Returns all if None.
+    :returns: dict of:
+    {<word>: {"count": <int>, "matches": [<str>,], "files": [<str>,]}}
+    Where:
+    * `count` = number of matches.
+    * `matches` = list of matched sentences.
+    * `files` = list of filenames with matched sentences.
+    """
+    # TODO: separate counter logic from result dict generation ??
+    # TODO: reduce the number of loops to generate the `ret_dict`!!
+    ret_dict = {}
+    _counters = [
+        _get_word_counts(x) for k, v in orig.items() for x in v["filtered_tokens"]
+    ]
+    _total_counter = _sum_collection_counters(_counters)
+    ret_dict = {
+        k: {"count": v} for k, v in _total_counter.most_common(most_common)
+    }
+    for _word in ret_dict.keys():
+        ret_dict[_word].update(_get_matches(_word, orig))
+    return ret_dict

--- a/python_homework_nlp/normaliser.py
+++ b/python_homework_nlp/normaliser.py
@@ -1,24 +1,22 @@
+import logging
+
+from nltk import download
 from nltk import word_tokenize
 from nltk.stem.snowball import SnowballStemmer
+
+log = logging.getLogger(__name__)
 
 
 def tokenize(string: str) -> str:
     # Requires: `nltk.download('punkt')`
-    # TODO: gracefully handle:
-    #     raise LookupError(resource_not_found)
-    #     LookupError:
-    #     **********************************************************************
-    #       Resource punkt not found.
-    #       Please use the NLTK Downloader to obtain the resource:
-    #
-    #       >>> import nltk
-    #       >>> nltk.download('punkt')
-    #
-    #       For more information see: https://www.nltk.org/data.html
-    #
-    #       Attempted to load tokenizers/punkt/PY3/english.pickle
-
-    return word_tokenize(string)
+    try:
+        return word_tokenize(string)
+    except LookupError as e:
+        # TOOD: switch to upfront download/gathering of NLTK Data, to simplify
+        # these functions.
+        log.debug("Tokenize exception: %r", e)
+        download("punkt")
+        return word_tokenize(string)
 
 
 def get_stems(string: str) -> list:
@@ -30,5 +28,11 @@ def get_stems(string: str) -> list:
     # Requires: `nltk.download("stopwords")`
     _tokens = tokenize(string)
     # TODO: Create `stemmer` once.
-    stemmer = SnowballStemmer("english", ignore_stopwords=True)
+    try:
+        stemmer = SnowballStemmer("english", ignore_stopwords=True)
+    except LookupError as e:
+        log.debug("Stem exception: %r", e)
+        download("stopwords")
+        stemmer = SnowballStemmer("english", ignore_stopwords=True)
+
     return [stemmer.stem(x) for x in _tokens]

--- a/python_homework_nlp/normaliser.py
+++ b/python_homework_nlp/normaliser.py
@@ -1,32 +1,33 @@
 import logging
 
 from nltk import download
-from nltk import word_tokenize
+from nltk import sent_tokenize, word_tokenize
 from nltk.stem.snowball import SnowballStemmer
 
 log = logging.getLogger(__name__)
 
 
-def tokenize(string: str) -> str:
+def tokenize(string: str) -> list:
     # Requires: `nltk.download('punkt')`
     try:
-        return word_tokenize(string)
+        sentences = sent_tokenize(string)
     except LookupError as e:
         # TOOD: switch to upfront download/gathering of NLTK Data, to simplify
         # these functions.
         log.debug("Tokenize exception: %r", e)
         download("punkt")
-        return word_tokenize(string)
+        sentences = sent_tokenize(string)
+
+    return [word_tokenize(sentence) for sentence in sentences]
 
 
-def get_stems(string: str) -> list:
+def get_stems(tokens: list) -> list:
     """Parses the string and returns a string with all of the _"stemmed"_
     versions of the words. Stemming is process of reducing words to their
     base/root/stem version. eg. fishing, fished, and fisher to the stem fish.
     """
     # See: https://www.nltk.org/howto/stem.html#unit-tests-for-snowball-stemmer
     # Requires: `nltk.download("stopwords")`
-    _tokens = tokenize(string)
     # TODO: Create `stemmer` once.
     try:
         stemmer = SnowballStemmer("english", ignore_stopwords=True)
@@ -35,4 +36,4 @@ def get_stems(string: str) -> list:
         download("stopwords")
         stemmer = SnowballStemmer("english", ignore_stopwords=True)
 
-    return [stemmer.stem(x) for x in _tokens]
+    return [stemmer.stem(x) for x in tokens]

--- a/python_homework_nlp/normaliser.py
+++ b/python_homework_nlp/normaliser.py
@@ -1,10 +1,20 @@
 import logging
+import string
 
 from nltk import download
 from nltk import sent_tokenize, word_tokenize
+from nltk.corpus import stopwords
 from nltk.stem.snowball import SnowballStemmer
 
 log = logging.getLogger(__name__)
+STOPWORDS_EN = stopwords.words("english")
+STOPWORDS_EN.extend(string.punctuation)
+
+# TODO: class for NLP workflow:
+#
+# 1. Tokenize sentences/words.
+# 2. Filter out _"stop words"_.
+# 3. Stem words.
 
 
 def tokenize(string: str) -> list:
@@ -19,6 +29,13 @@ def tokenize(string: str) -> list:
         sentences = sent_tokenize(string)
 
     return [word_tokenize(sentence) for sentence in sentences]
+
+
+def get_tokens_without_stopwords(
+    tokens: list, stop_words: list = STOPWORDS_EN
+) -> list:
+    """Gets a new list of tokens with all stopwords removed."""
+    return [x for x in tokens if x not in stop_words]
 
 
 def get_stems(tokens: list) -> list:

--- a/python_homework_nlp/normaliser.py
+++ b/python_homework_nlp/normaliser.py
@@ -6,8 +6,12 @@ from nltk import download
 from nltk import sent_tokenize, word_tokenize
 from nltk.corpus import stopwords
 from nltk.stem.snowball import SnowballStemmer
+from python_homework_nlp.common import download_nltk_data
 
 log = logging.getLogger(__name__)
+# TODO: Move to `main()` and call before tests (`conftest.py` is not earlier
+# enough due to import side-effects!!).
+download_nltk_data()
 STOPWORDS_EN = stopwords.words("english")
 STOPWORDS_EN.extend(string.punctuation)
 

--- a/python_homework_nlp/normaliser.py
+++ b/python_homework_nlp/normaliser.py
@@ -1,6 +1,7 @@
 import logging
 import string
 
+from collections import Counter
 from nltk import download
 from nltk import sent_tokenize, word_tokenize
 from nltk.corpus import stopwords
@@ -46,6 +47,9 @@ def get_stems(tokens: list) -> list:
     # See: https://www.nltk.org/howto/stem.html#unit-tests-for-snowball-stemmer
     # Requires: `nltk.download("stopwords")`
     # TODO: Create `stemmer` once.
+
+    # TODO: Switch to Lemmatizing (eg. `nltk.stem.WorkNetLemmatizer`) if the
+    # accuracy is poor and I'm okay with the time hit.
     try:
         stemmer = SnowballStemmer("english", ignore_stopwords=True)
     except LookupError as e:
@@ -54,3 +58,72 @@ def get_stems(tokens: list) -> list:
         stemmer = SnowballStemmer("english", ignore_stopwords=True)
 
     return [stemmer.stem(x) for x in tokens]
+
+
+def _get_word_counts(tokens: list) -> Counter:
+    return Counter(tokens)
+
+
+def _sum_collection_counters(counters: list) -> Counter:
+    total_counter: Counter = Counter()
+    for x in counters:
+        total_counter += x
+    return total_counter
+
+
+def _get_matches(word: str, orig: dict) -> dict:
+    """Returns all files + sentences that match a given word.
+
+    :param str word: word to find matches for.
+    :param dict orig: Original nested dictionary of files and original sentences
+    + filtered tokens.
+    {<filename>: {"original_sentences": [<str>,], "filtered_tokens": [[<str>,],]}}
+    :returns: dict of: {"matches": <list>, "files": <list>}
+    """
+    # TOOD: test
+    _matched_files = []
+    _matched_sentences = []
+    for _file in orig:
+        _matches = _get_matches_by_word(word, orig[_file]["original_sentences"])
+        if _matches:
+            _matched_files.append(_file)
+            _matched_sentences.extend(_matches)
+
+    return {"matches": _matched_sentences, "files": _matched_files}
+
+
+def _get_matches_by_word(word: str, original_sentences: list) -> list:
+    """Returns all sentences that match a given word.
+
+    :param str word: word to find matches for.
+    :param list orig_sentences: List of sentences to find matches in.
+    :returns: list of matched sentences.
+    """
+    # TOOD: test
+    return [x for x in original_sentences if word in x.lower()]
+
+
+def counter(orig: dict) -> dict:
+    """Counts number of words duplicate words in a filtered tokens list +
+    generates the return structure.
+
+    :param dict orig: Original nested dictionary of files and original sentences
+    + filtered tokens.
+    {<filename>: {"original_sentences": [<str>,], "filtered_tokens": [[<str>,],]}}
+    :returns: dict of:
+    {<word>: {"count": <int>, "matches": [<str>,], "files": [<str>,]}}
+    Where:
+    * `count` = number of matches.
+    * `matches` = list of matched sentences.
+    * `files` = list of filenames with matched sentences.
+    """
+    # TODO: reduce the number of loops to generate the `ret_dict`!!
+    ret_dict = {}
+    _counters = [
+        _get_word_counts(x) for k, v in orig.items() for x in v["filtered_tokens"]
+    ]
+    _total_counter = _sum_collection_counters(_counters)
+    ret_dict = {k: {"count": v} for k, v in _total_counter.items()}
+    for _word in ret_dict.keys():
+        ret_dict[_word].update(_get_matches(_word, orig))
+    return ret_dict

--- a/python_homework_nlp/normaliser.py
+++ b/python_homework_nlp/normaliser.py
@@ -103,13 +103,14 @@ def _get_matches_by_word(word: str, original_sentences: list) -> list:
     return [x for x in original_sentences if word in x.lower()]
 
 
-def counter(orig: dict) -> dict:
+def counter(orig: dict, most_common: int = None) -> dict:
     """Counts number of words duplicate words in a filtered tokens list +
     generates the return structure.
 
     :param dict orig: Original nested dictionary of files and original sentences
     + filtered tokens.
     {<filename>: {"original_sentences": [<str>,], "filtered_tokens": [[<str>,],]}}
+    :param int most_common: Returns X most common words. Returns all if None.
     :returns: dict of:
     {<word>: {"count": <int>, "matches": [<str>,], "files": [<str>,]}}
     Where:
@@ -123,7 +124,9 @@ def counter(orig: dict) -> dict:
         _get_word_counts(x) for k, v in orig.items() for x in v["filtered_tokens"]
     ]
     _total_counter = _sum_collection_counters(_counters)
-    ret_dict = {k: {"count": v} for k, v in _total_counter.items()}
+    ret_dict = {
+        k: {"count": v} for k, v in _total_counter.most_common(most_common)
+    }
     for _word in ret_dict.keys():
         ret_dict[_word].update(_get_matches(_word, orig))
     return ret_dict

--- a/python_homework_nlp/normaliser.py
+++ b/python_homework_nlp/normaliser.py
@@ -1,7 +1,6 @@
 import logging
 import string
 
-from collections import Counter
 from nltk import download
 from nltk import sent_tokenize, word_tokenize
 from nltk.corpus import stopwords
@@ -63,75 +62,3 @@ def get_stems(tokens: list) -> list:
         stemmer = SnowballStemmer("english", ignore_stopwords=True)
 
     return [stemmer.stem(x) for x in tokens]
-
-
-def _get_word_counts(tokens: list) -> Counter:
-    return Counter(tokens)
-
-
-def _sum_collection_counters(counters: list) -> Counter:
-    total_counter: Counter = Counter()
-    for x in counters:
-        total_counter += x
-    return total_counter
-
-
-def _get_matches(word: str, orig: dict) -> dict:
-    """Returns all files + sentences that match a given word.
-
-    :param str word: word to find matches for.
-    :param dict orig: Original nested dictionary of files and original sentences
-    + filtered tokens.
-    {<filename>: {"original_sentences": [<str>,], "filtered_tokens": [[<str>,],]}}
-    :returns: dict of: {"matches": <list>, "files": <list>}
-    """
-    # TOOD: test
-    _matched_files = []
-    _matched_sentences = []
-    for _file in orig:
-        _matches = _get_matches_by_word(word, orig[_file]["original_sentences"])
-        if _matches:
-            _matched_files.append(_file)
-            _matched_sentences.extend(_matches)
-
-    return {"matches": _matched_sentences, "files": _matched_files}
-
-
-def _get_matches_by_word(word: str, original_sentences: list) -> list:
-    """Returns all sentences that match a given word.
-
-    :param str word: word to find matches for.
-    :param list orig_sentences: List of sentences to find matches in.
-    :returns: list of matched sentences.
-    """
-    # TOOD: test
-    return [x for x in original_sentences if word in x.lower()]
-
-
-def counter(orig: dict, most_common: int = None) -> dict:
-    """Counts number of words duplicate words in a filtered tokens list +
-    generates the return structure.
-
-    :param dict orig: Original nested dictionary of files and original sentences
-    + filtered tokens.
-    {<filename>: {"original_sentences": [<str>,], "filtered_tokens": [[<str>,],]}}
-    :param int most_common: Returns X most common words. Returns all if None.
-    :returns: dict of:
-    {<word>: {"count": <int>, "matches": [<str>,], "files": [<str>,]}}
-    Where:
-    * `count` = number of matches.
-    * `matches` = list of matched sentences.
-    * `files` = list of filenames with matched sentences.
-    """
-    # TODO: reduce the number of loops to generate the `ret_dict`!!
-    ret_dict = {}
-    _counters = [
-        _get_word_counts(x) for k, v in orig.items() for x in v["filtered_tokens"]
-    ]
-    _total_counter = _sum_collection_counters(_counters)
-    ret_dict = {
-        k: {"count": v} for k, v in _total_counter.most_common(most_common)
-    }
-    for _word in ret_dict.keys():
-        ret_dict[_word].update(_get_matches(_word, orig))
-    return ret_dict

--- a/python_homework_nlp/normaliser.py
+++ b/python_homework_nlp/normaliser.py
@@ -1,0 +1,34 @@
+from nltk import word_tokenize
+from nltk.stem.snowball import SnowballStemmer
+
+
+def tokenize(string: str) -> str:
+    # Requires: `nltk.download('punkt')`
+    # TODO: gracefully handle:
+    #     raise LookupError(resource_not_found)
+    #     LookupError:
+    #     **********************************************************************
+    #       Resource punkt not found.
+    #       Please use the NLTK Downloader to obtain the resource:
+    #
+    #       >>> import nltk
+    #       >>> nltk.download('punkt')
+    #
+    #       For more information see: https://www.nltk.org/data.html
+    #
+    #       Attempted to load tokenizers/punkt/PY3/english.pickle
+
+    return word_tokenize(string)
+
+
+def get_stems(string: str) -> list:
+    """Parses the string and returns a string with all of the _"stemmed"_
+    versions of the words. Stemming is process of reducing words to their
+    base/root/stem version. eg. fishing, fished, and fisher to the stem fish.
+    """
+    # See: https://www.nltk.org/howto/stem.html#unit-tests-for-snowball-stemmer
+    # Requires: `nltk.download("stopwords")`
+    _tokens = tokenize(string)
+    # TODO: Create `stemmer` once.
+    stemmer = SnowballStemmer("english", ignore_stopwords=True)
+    return [stemmer.stem(x) for x in _tokens]

--- a/python_homework_nlp/normaliser.py
+++ b/python_homework_nlp/normaliser.py
@@ -24,7 +24,8 @@ def tokenize(string: str) -> list:
         sentences = sent_tokenize(string)
     except LookupError as e:
         # TOOD: switch to upfront download/gathering of NLTK Data, to simplify
-        # these functions.
+        # these functions. Call:
+        # `python_homework_nlp.common.download_nltk_data` from `main()`.
         log.debug("Tokenize exception: %r", e)
         download("punkt")
         sentences = sent_tokenize(string)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+from python_homework_nlp.common import download_nltk_data
+
+
+@pytest.fixture(autouse=True, scope="session")
+def download_required_nltk_data():
+    download_nltk_data()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,4 +4,6 @@ from python_homework_nlp.common import download_nltk_data
 
 @pytest.fixture(autouse=True, scope="session")
 def download_required_nltk_data():
+    # FIXME: call before tests (`conftest.py` is not earlier enough due to
+    # import side-effects!!).
     download_nltk_data()

--- a/tests/test_counter.py
+++ b/tests/test_counter.py
@@ -1,0 +1,93 @@
+import pytest
+from python_homework_nlp.counter import counter
+
+
+class TestCounter:
+    @pytest.mark.parametrize(
+        "actual,exp,most_common",
+        (
+            (
+                {
+                    "file1": {
+                        "original_sentences": [
+                            "First sentence.",
+                            "Second is sentences.",
+                            "Final SENTENCE!",
+                        ],
+                        "filtered_tokens": [
+                            ["first", "sentence"],
+                            ["second", "sentence"],
+                            ["final", "sentence"],
+                        ],
+                    }
+                },
+                {
+                    "final": {
+                        "count": 1,
+                        "matches": ["Final SENTENCE!"],
+                        "files": [
+                            "file1",
+                        ],
+                    },
+                    "first": {
+                        "count": 1,
+                        "matches": ["First sentence."],
+                        "files": [
+                            "file1",
+                        ],
+                    },
+                    "second": {
+                        "count": 1,
+                        "matches": ["Second is sentences."],
+                        "files": [
+                            "file1",
+                        ],
+                    },
+                    "sentence": {
+                        "count": 3,
+                        "matches": [
+                            "First sentence.",
+                            "Second is sentences.",
+                            "Final SENTENCE!",
+                        ],
+                        "files": [
+                            "file1",
+                        ],
+                    },
+                },
+                None,
+            ),
+            (
+                {
+                    "file1": {
+                        "original_sentences": [
+                            "First sentence.",
+                            "Second is sentences.",
+                            "Final SENTENCE!",
+                        ],
+                        "filtered_tokens": [
+                            ["first", "sentence"],
+                            ["second", "sentence"],
+                            ["final", "sentence"],
+                        ],
+                    }
+                },
+                {
+                    "sentence": {
+                        "count": 3,
+                        "matches": [
+                            "First sentence.",
+                            "Second is sentences.",
+                            "Final SENTENCE!",
+                        ],
+                        "files": [
+                            "file1",
+                        ],
+                    },
+                },
+                1,
+            ),
+        ),
+    )
+    def test_counter(self, actual, exp, most_common):
+        assert counter(actual, most_common) == exp

--- a/tests/test_normaliser.py
+++ b/tests/test_normaliser.py
@@ -1,6 +1,7 @@
 import pytest
 from nltk.corpus import stopwords
 from python_homework_nlp.normaliser import (
+    counter,
     get_stems,
     get_tokens_without_stopwords,
     tokenize,
@@ -68,3 +69,54 @@ class TestNormaliser:
     )
     def test_tokenize(self, actual, exp):
         assert tokenize(actual) == exp
+
+    def test_counter(self):
+        actual = {
+            "file1": {
+                "original_sentences": [
+                    "First sentence.",
+                    "Second is sentences.",
+                    "Final SENTENCE!",
+                ],
+                "filtered_tokens": [
+                    ["first", "sentence"],
+                    ["second", "sentence"],
+                    ["final", "sentence"],
+                ],
+            }
+        }
+        exp = {
+            "final": {
+                "count": 1,
+                "matches": ["Final SENTENCE!"],
+                "files": [
+                    "file1",
+                ],
+            },
+            "first": {
+                "count": 1,
+                "matches": ["First sentence."],
+                "files": [
+                    "file1",
+                ],
+            },
+            "second": {
+                "count": 1,
+                "matches": ["Second is sentences."],
+                "files": [
+                    "file1",
+                ],
+            },
+            "sentence": {
+                "count": 3,
+                "matches": [
+                    "First sentence.",
+                    "Second is sentences.",
+                    "Final SENTENCE!",
+                ],
+                "files": [
+                    "file1",
+                ],
+            },
+        }
+        assert counter(actual) == exp

--- a/tests/test_normaliser.py
+++ b/tests/test_normaliser.py
@@ -1,5 +1,11 @@
 import pytest
-from python_homework_nlp.normaliser import get_stems, tokenize
+from nltk.corpus import stopwords
+from python_homework_nlp.normaliser import (
+    get_stems,
+    get_tokens_without_stopwords,
+    tokenize,
+    STOPWORDS_EN,
+)
 
 
 class TestNormaliser:
@@ -8,6 +14,32 @@ class TestNormaliser:
     )
     def test_get_stems(self, actual, exp):
         assert get_stems(actual) == exp
+
+    @pytest.mark.parametrize(
+        "actual,exp,stop_words",
+        (
+            (
+                ["This", "is", "a", "sentence", "with", "stopwords", "."],
+                ["This", "sentence", "stopwords", "."],
+                stopwords.words("english"),
+            ),
+            (
+                ["This", "is", "a", "sentence", "with", "stopwords", "."],
+                ["This", "sentence", "stopwords"],
+                None,
+            ),
+            (
+                ["This", "is", "a", "sentence", "with", "stopwords", "."],
+                ["This", "sentence", "stopwords"],
+                STOPWORDS_EN,
+            ),
+        ),
+    )
+    def test_get_tokens_without_stopwords(self, actual, exp, stop_words):
+        if stop_words:
+            assert get_tokens_without_stopwords(actual, stop_words) == exp
+        else:
+            assert get_tokens_without_stopwords(actual) == exp
 
     @pytest.mark.parametrize(
         "actual,exp",

--- a/tests/test_normaliser.py
+++ b/tests/test_normaliser.py
@@ -1,7 +1,6 @@
 import pytest
 from nltk.corpus import stopwords
 from python_homework_nlp.normaliser import (
-    counter,
     get_stems,
     get_tokens_without_stopwords,
     tokenize,
@@ -69,92 +68,3 @@ class TestNormaliser:
     )
     def test_tokenize(self, actual, exp):
         assert tokenize(actual) == exp
-
-    @pytest.mark.parametrize(
-        "actual,exp,most_common",
-        (
-            (
-                {
-                    "file1": {
-                        "original_sentences": [
-                            "First sentence.",
-                            "Second is sentences.",
-                            "Final SENTENCE!",
-                        ],
-                        "filtered_tokens": [
-                            ["first", "sentence"],
-                            ["second", "sentence"],
-                            ["final", "sentence"],
-                        ],
-                    }
-                },
-                {
-                    "final": {
-                        "count": 1,
-                        "matches": ["Final SENTENCE!"],
-                        "files": [
-                            "file1",
-                        ],
-                    },
-                    "first": {
-                        "count": 1,
-                        "matches": ["First sentence."],
-                        "files": [
-                            "file1",
-                        ],
-                    },
-                    "second": {
-                        "count": 1,
-                        "matches": ["Second is sentences."],
-                        "files": [
-                            "file1",
-                        ],
-                    },
-                    "sentence": {
-                        "count": 3,
-                        "matches": [
-                            "First sentence.",
-                            "Second is sentences.",
-                            "Final SENTENCE!",
-                        ],
-                        "files": [
-                            "file1",
-                        ],
-                    },
-                },
-                None,
-            ),
-            (
-                {
-                    "file1": {
-                        "original_sentences": [
-                            "First sentence.",
-                            "Second is sentences.",
-                            "Final SENTENCE!",
-                        ],
-                        "filtered_tokens": [
-                            ["first", "sentence"],
-                            ["second", "sentence"],
-                            ["final", "sentence"],
-                        ],
-                    }
-                },
-                {
-                    "sentence": {
-                        "count": 3,
-                        "matches": [
-                            "First sentence.",
-                            "Second is sentences.",
-                            "Final SENTENCE!",
-                        ],
-                        "files": [
-                            "file1",
-                        ],
-                    },
-                },
-                1,
-            ),
-        ),
-    )
-    def test_counter(self, actual, exp, most_common):
-        assert counter(actual, most_common) == exp

--- a/tests/test_normaliser.py
+++ b/tests/test_normaliser.py
@@ -70,53 +70,91 @@ class TestNormaliser:
     def test_tokenize(self, actual, exp):
         assert tokenize(actual) == exp
 
-    def test_counter(self):
-        actual = {
-            "file1": {
-                "original_sentences": [
-                    "First sentence.",
-                    "Second is sentences.",
-                    "Final SENTENCE!",
-                ],
-                "filtered_tokens": [
-                    ["first", "sentence"],
-                    ["second", "sentence"],
-                    ["final", "sentence"],
-                ],
-            }
-        }
-        exp = {
-            "final": {
-                "count": 1,
-                "matches": ["Final SENTENCE!"],
-                "files": [
-                    "file1",
-                ],
-            },
-            "first": {
-                "count": 1,
-                "matches": ["First sentence."],
-                "files": [
-                    "file1",
-                ],
-            },
-            "second": {
-                "count": 1,
-                "matches": ["Second is sentences."],
-                "files": [
-                    "file1",
-                ],
-            },
-            "sentence": {
-                "count": 3,
-                "matches": [
-                    "First sentence.",
-                    "Second is sentences.",
-                    "Final SENTENCE!",
-                ],
-                "files": [
-                    "file1",
-                ],
-            },
-        }
-        assert counter(actual) == exp
+    @pytest.mark.parametrize(
+        "actual,exp,most_common",
+        (
+            (
+                {
+                    "file1": {
+                        "original_sentences": [
+                            "First sentence.",
+                            "Second is sentences.",
+                            "Final SENTENCE!",
+                        ],
+                        "filtered_tokens": [
+                            ["first", "sentence"],
+                            ["second", "sentence"],
+                            ["final", "sentence"],
+                        ],
+                    }
+                },
+                {
+                    "final": {
+                        "count": 1,
+                        "matches": ["Final SENTENCE!"],
+                        "files": [
+                            "file1",
+                        ],
+                    },
+                    "first": {
+                        "count": 1,
+                        "matches": ["First sentence."],
+                        "files": [
+                            "file1",
+                        ],
+                    },
+                    "second": {
+                        "count": 1,
+                        "matches": ["Second is sentences."],
+                        "files": [
+                            "file1",
+                        ],
+                    },
+                    "sentence": {
+                        "count": 3,
+                        "matches": [
+                            "First sentence.",
+                            "Second is sentences.",
+                            "Final SENTENCE!",
+                        ],
+                        "files": [
+                            "file1",
+                        ],
+                    },
+                },
+                None,
+            ),
+            (
+                {
+                    "file1": {
+                        "original_sentences": [
+                            "First sentence.",
+                            "Second is sentences.",
+                            "Final SENTENCE!",
+                        ],
+                        "filtered_tokens": [
+                            ["first", "sentence"],
+                            ["second", "sentence"],
+                            ["final", "sentence"],
+                        ],
+                    }
+                },
+                {
+                    "sentence": {
+                        "count": 3,
+                        "matches": [
+                            "First sentence.",
+                            "Second is sentences.",
+                            "Final SENTENCE!",
+                        ],
+                        "files": [
+                            "file1",
+                        ],
+                    },
+                },
+                1,
+            ),
+        ),
+    )
+    def test_counter(self, actual, exp, most_common):
+        assert counter(actual, most_common) == exp

--- a/tests/test_normaliser.py
+++ b/tests/test_normaliser.py
@@ -1,29 +1,38 @@
+import pytest
 from python_homework_nlp.normaliser import get_stems, tokenize
 
 
 class TestNormaliser:
-    def test_get_stems(self):
-        actual = "look looking looked"
-        exp = ["look"] * 3
+    @pytest.mark.parametrize(
+        "actual,exp", ((["look", "looking", "looked"], ["look"] * 3),)
+    )
+    def test_get_stems(self, actual, exp):
         assert get_stems(actual) == exp
 
-    def test_tokenize(self):
-        actual = (
-            "At eight o'clock on Thursday morning Arthur didn't feel very good."
-        )
-        exp = [
-            "At",
-            "eight",
-            "o'clock",
-            "on",
-            "Thursday",
-            "morning",
-            "Arthur",
-            "did",
-            "n't",
-            "feel",
-            "very",
-            "good",
-            ".",
-        ]
+    @pytest.mark.parametrize(
+        "actual,exp",
+        (
+            (
+                "Arthur didn't feel good at eight o'clock.",
+                [
+                    [
+                        "Arthur",
+                        "did",
+                        "n't",
+                        "feel",
+                        "good",
+                        "at",
+                        "eight",
+                        "o'clock",
+                        ".",
+                    ],
+                ],
+            ),
+            (
+                "First sentence. Second sentence.",
+                [["First", "sentence", "."], ["Second", "sentence", "."]],
+            ),
+        ),
+    )
+    def test_tokenize(self, actual, exp):
         assert tokenize(actual) == exp

--- a/tests/test_normaliser.py
+++ b/tests/test_normaliser.py
@@ -1,0 +1,29 @@
+from python_homework_nlp.normaliser import get_stems, tokenize
+
+
+class TestNormaliser:
+    def test_get_stems(self):
+        actual = "look looking looked"
+        exp = ["look"] * 3
+        assert get_stems(actual) == exp
+
+    def test_tokenize(self):
+        actual = (
+            "At eight o'clock on Thursday morning Arthur didn't feel very good."
+        )
+        exp = [
+            "At",
+            "eight",
+            "o'clock",
+            "on",
+            "Thursday",
+            "morning",
+            "Arthur",
+            "did",
+            "n't",
+            "feel",
+            "very",
+            "good",
+            ".",
+        ]
+        assert tokenize(actual) == exp


### PR DESCRIPTION
Use `nltk` to normalise sentences into a filtered list of tokens. Also added Counter logic which returns a nested structure of filtered tokens with count/files/matches.

* `normaliser.py` contains functions to: tokenize, stem & filter sentences into a list of words. Final function returns a nested dict of: `{<filename>: {"original_sentences": [<str>,], "filtered_tokens": [[<str>,],]}}`
* `counter.py` contains functions to take the nested dict from `normaliser.py` and find all (or `X` most common words) matches + counts + files matched. Output: `{<word>: {"count": <int>, "matches": [<str>,], "files": [<str>,]}}`
* Common function to download all required NLTK data.
* Ignore `mypy` missing type errors for the `nltk` package.
* Fix up `emacs` `compile-command` call to use `poetry run` throughout + more verbose `pytest` output.